### PR TITLE
 Updated endpoint from ASM to ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The pattern to manipulate any Service Bus resource is similar and follows a comm
     var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
 
     var result = await context.AcquireTokenAsync(
-        "https://management.core.windows.net/",
+        "https://management.azure.com/",
         new ClientCredential(clientId, clientSecret)
     );
     ```

--- a/src/service-bus-dotnet-management/ServiceBusManagementSample.cs
+++ b/src/service-bus-dotnet-management/ServiceBusManagementSample.cs
@@ -275,7 +275,7 @@ namespace AzureServiceBusDotNetManagement
 					var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
 
 					var result = await context.AcquireTokenAsync(
-						"https://management.core.windows.net/",
+						"https://management.azure.com/",
 						new ClientCredential(clientId, clientSecret)
 					);
 


### PR DESCRIPTION
ASM API will be deprecated in Nov/2019 so we have to change endpoint to ARM.
https://blogs.msdn.microsoft.com/servicebus/2018/11/01/deprecating-service-management-support-for-azure-service-bus-relay-and-event-hubs/
https://docs.microsoft.com/en-us/rest/api/servicebus/ (check Important note)

ARM API: https://docs.microsoft.com/en-us/rest/api/servicebus/queues/createorupdate
old ASM(classic RDFE) API: https://docs.microsoft.com/en-us/rest/api/servicebus/create-queue